### PR TITLE
Add missing schema version

### DIFF
--- a/dist/RedactorAnchors.php
+++ b/dist/RedactorAnchors.php
@@ -10,6 +10,7 @@ use yii\base\Event;
 
 class RedactorAnchors extends Plugin
 {
+    public string $schemaVersion = '2.0';
     public static $plugin;
 
     public function init()


### PR DESCRIPTION
The new 1.4.2 version update is causing issues with project config files. When installing the update and applying the project config files I get the following error message:

![image](https://github.com/heidkaemper/craft-redactor-anchors/assets/128366984/30abdf0e-965d-4b01-bc83-5f1cbaf5f4d7)

After digging into the database and the project.yaml file I found that everything is correct (the project.yaml schema version for the redactor-anchors plugin is 2.0; the schema version on the plugins table is 2.0 and the schema version on the projectconfig table is 2.0) but the schema version retrieved by Craft is 1.0.0 (the default, set in craftcms/cms/src/base/PluginTrait.php) because the explicit schemaVersion is missing from the plugin. (The code that checks the schema version is on craftcms/cms/src/console/controllers/ProjectConfigController.php:280)

The issue is preventing every kind of project config update to be applied.

Adding `public string $schemaVersion = '2.0';` in the plugin declaration fixes the issue.